### PR TITLE
Add support for provisioning and configuring a bastion host

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Deployment scripts for provisioning and configuring JORE4 infrastructure in Azur
     - [1. Provisioning resource groups and network](#1-provisioning-resource-groups-and-network)
     - [2. Provisioning key vaults](#2-provisioning-key-vaults)
     - [3. Provisioning a log workspace](#3-provisioning-a-log-workspace)
-    - [4. Provisioning an application gateway](#4-provisioning-an-application-gateway)
-    - [5. Provisioning a Kubernetes cluster](#5-provisioning-a-kubernetes-cluster)
+    - [4. Provisioning a bastion host and configuring it](#4-provisioning-a-bastion-host-and-configuring-it)
+    - [5. Provisioning an application gateway](#5-provisioning-an-application-gateway)
+    - [6. Provisioning a Kubernetes cluster](#6-provisioning-a-kubernetes-cluster)
       - [Configuration](#configuration)
       - [Docker images](#docker-images)
       - [Networking](#networking)
@@ -25,8 +26,8 @@ Deployment scripts for provisioning and configuring JORE4 infrastructure in Azur
       - [Application Gateway Ingress Controller](#application-gateway-ingress-controller)
       - [Accessing the Cluster](#accessing-the-cluster)
       - [Troubleshooting](#troubleshooting)
-    - [6. Provisioning a Domain](#6-provisioning-a-domain)
-    - [7. Provisioning a Certificate](#7-provisioning-a-certificate)
+    - [7. Provisioning a Domain](#7-provisioning-a-domain)
+    - [8. Provisioning a Certificate](#8-provisioning-a-certificate)
   - [Configuration](#configuration-1)
     - [Adding services to Kubernetes cluster](#adding-services-to-kubernetes-cluster)
 
@@ -148,7 +149,34 @@ collected (including the Kubernetes pods logs).
 You should also manually set up Security Center auto-provisioning for the subscription ("jore4").
 See https://docs.microsoft.com/en-us/azure/security-center/security-center-enable-data-collection
 
-### 4. Provisioning an application gateway
+### 4. Provisioning a bastion host and configuring it
+
+To provision the bastion host, run
+```
+playdev play-provision-bastion-host.yml
+```
+
+This will
+- create a virtual machine that has network interfaces in both private and public subnets of the
+  vnet created by `play-provision-rg-and-nets.yml`,
+- assign a public IP to that VM's public subnet network interface,
+- download the developer team CA public key from the common key vault and
+- install the CA public key on the bastion host to enable project members to log in.
+
+For initial deployment of the CA public key, the ansible environment's public SSH key is used. If
+the project CA keypair is changed at a later stage, it has to be updated manually on the bastion
+host in the files
+- /etc/ssh/ca.pub and
+- /home/hsladmin/.ssh/authorized_keys
+
+For instructions on how to connect to the bastion host, see the
+[Wiki](https://github.com/HSLdevcom/jore4/blob/main/wiki/onboarding.md).
+
+The playbook `play-provision-bastion-host.yml` and its roles and templates have been adopted from
+the playbooks `play-provision-bastion-host.yml` and `play-configure-server-ssh.yml` found in the
+the repository https://gitlab.hsl.fi/platforms/server-based .
+
+### 5. Provisioning an application gateway
 
 ```
 playdev play-provision-appgateway.yml
@@ -170,7 +198,7 @@ https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-ov
 Warning: if you rerun this playbook, it will also remove all the existing listeners that AGIC
 has created. If happens so, redo the Kubernetes deployment to recreate all the listeners.
 
-### 5. Provisioning a Kubernetes cluster
+### 6. Provisioning a Kubernetes cluster
 
 ```
 playdev play-provision-aks.yml
@@ -254,7 +282,7 @@ the fact that the controller was created before the permissions were assigned in
 restarting the AGIC controller by setting the number of replicas first to 0 and then 1.
 `kubectl scale deployment ingress-appgw-deployment --replicas=0 --namespace kube-system`
 
-### 6. Provisioning a Domain
+### 7. Provisioning a Domain
 
 ```
 playdev play-provision-dns-zone.yml
@@ -290,7 +318,7 @@ spec:
 [...]
 ```
 
-### 7. Provisioning a Certificate
+### 8. Provisioning a Certificate
 
 You should provision an App Service Certificate manually. There has been attempts to create it
 automatically with an ARM template, but it's quite buggy so don't do it! It's now created anyway, so

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -8,3 +8,16 @@ az_resource_group_name: "{{ az_project_name }}-{{ az_environment }}"
 #Common packages
 default_packages:
   - anacron
+
+# Bastion host
+az_initial_ssh_public_key: "{{ lookup('file', '~/.ssh/ansible_initial_key_rsa.pub') }}"
+az_hardened_vm_image: # Note that this image has tight iptables firewall rules which are ok for a bastion, but will need to be customized for you service if used on other hosts
+  publisher: "center-for-internet-security-inc"
+  offer: "cis-ubuntu-linux-1804-l1"
+  sku: "cis-ubuntu1804-l1"
+  version: "latest"
+az_hardened_vm_plan:
+  name: "cis-ubuntu1804-l1"
+  product: "cis-ubuntu-linux-1804-l1"
+  publisher: "center-for-internet-security-inc"
+az_initial_username: "hsladmin"

--- a/ansible/inventory/hsl-jore4.dev.azure_rm.yml
+++ b/ansible/inventory/hsl-jore4.dev.azure_rm.yml
@@ -1,2 +1,4 @@
 # required for all azure_rm inventory plugin configs
 plugin: azure_rm
+include_vm_resource_groups:
+  - hsl-jore4-dev

--- a/ansible/inventory/hsl-jore4.prod.azure_rm.yml
+++ b/ansible/inventory/hsl-jore4.prod.azure_rm.yml
@@ -1,2 +1,4 @@
 # required for all azure_rm inventory plugin configs
 plugin: azure_rm
+include_vm_resource_groups:
+  - hsl-jore4-prod

--- a/ansible/inventory/hsl-jore4.test.azure_rm.yml
+++ b/ansible/inventory/hsl-jore4.test.azure_rm.yml
@@ -1,2 +1,4 @@
 # required for all azure_rm inventory plugin configs
 plugin: azure_rm
+include_vm_resource_groups:
+  - hsl-jore4-test

--- a/ansible/play-provision-bastion-host.yml
+++ b/ansible/play-provision-bastion-host.yml
@@ -1,0 +1,31 @@
+---
+- name: "Create the bastion host for {{ az_environment }}"
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+    - azure_bastion_host
+
+- name: "Fetch public CA SSH key {{ az_environment }}"
+  hosts: "localhost"
+  connection: local
+  gather_facts: false
+  roles:
+    - fetch_server_ssh_pubkey
+
+- name: "Wait for bastion host to come up"
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - pause:
+        seconds: 30
+    - meta: refresh_inventory
+
+- name: "Configure bastion host to allow CA signed SSH keys for {{ az_environment }}"
+  hosts: "~.*-bastion.*"
+  user: "{{ init_user | default('hsladmin') }}"
+  gather_facts: false
+  become: true
+  roles:
+    - conf_server_ssh

--- a/ansible/roles/azure_bastion_host/tasks/main.yml
+++ b/ansible/roles/azure_bastion_host/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Create Azure Deployment for the bastion host
+  azure_rm_deployment:
+    resource_group: "{{ az_resource_group_name }}"
+    location: "{{ az_region_name }}"
+    name: "azure_bastion"
+    parameters:
+      project:
+        value: "{{ az_project_name }}"
+      environment:
+        value: "{{ az_environment }}"
+      vmName:
+        value: "{{ az_project_name }}-{{ az_environment }}-bastion"
+      initialSshKey:
+        value: "{{ az_initial_ssh_public_key }}"
+      vmImage:
+        value: "{{ az_hardened_vm_image }}"
+      vmPlan:
+        value: "{{ az_hardened_vm_plan }}"
+      requiredUpTime:
+        value: "{{ az_requireduptime_tag_default }}"
+    tags:
+      ansible: 'workaround'
+    template: "{{ lookup('file', 'templates/bastionhost.arm.json') }}"

--- a/ansible/roles/conf_server_ssh/tasks/main.yml
+++ b/ansible/roles/conf_server_ssh/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: copy CA public key to server
+  copy:
+    content: "{{ hostvars['localhost']['developer_openssh_pub_key'] }}"
+    dest: /etc/ssh/ca.pub
+
+- name: set trusted ca key in sshd_config
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    line: TrustedUserCAKeys /etc/ssh/ca.pub
+  become: yes
+
+- name: replace existing authorized key with ca authentication in authorized_keys
+  shell: echo "cert-authority {{ hostvars['localhost']['developer_openssh_pub_key'] }}" > /home/{{ az_initial_username }}/.ssh/authorized_keys

--- a/ansible/roles/fetch_server_ssh_pubkey/tasks/main.yml
+++ b/ansible/roles/fetch_server_ssh_pubkey/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: get developer OpenSSH public key
+  shell: az keyvault secret show --vault-name hsl-jore4-vault --name jore4-developer-ca-key-public --output tsv --query value
+  register: developer_openssh_pub_key_output
+
+- name: save the developer OpenSSH public key
+  set_fact:
+    developer_openssh_pub_key: "{{ developer_openssh_pub_key_output.stdout }}"

--- a/ansible/templates/bastionhost.arm.json
+++ b/ansible/templates/bastionhost.arm.json
@@ -1,0 +1,262 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "project": {
+           "type": "string",
+           "metadata": {
+                "description": "The short name of the project. Usually same as the name of the subscription in Azure."
+            }
+        },
+        "environment": {
+           "type": "string",
+           "metadata": {
+                "description": "The target environment. Typically dev, test or prod."
+            }
+        },
+        "initialSshKey": {
+           "type": "string",
+           "metadata": {
+                "description": "The initial public SSH key."
+            }
+        },
+        "location": {
+           "type": "string",
+           "metadata": {
+                "description": "The region used for the resources."
+            },
+            "defaultValue": "[resourceGroup().location]"
+        },
+        "vmName": {
+           "type": "string",
+           "metadata": {
+                "description": "The name of the bastion host."
+            },
+            "defaultValue": "[concat(parameters('project'), '-', parameters('environment'), '-bastion')]"
+        },
+        "vnetName": {
+           "type": "string",
+           "metadata": {
+                "description": "The name of the target VNet."
+            },
+            "defaultValue": "[concat(parameters('project'), '-', parameters('environment'), '-vnet')]"
+        },
+        "privateSubnetName": {
+           "type": "string",
+           "metadata": {
+                "description": "The name of the private subnet."
+            },
+            "defaultValue": "[concat(parameters('project'), '-', parameters('environment'), '-subnet-private')]"
+        },
+        "publicSubnetName": {
+           "type": "string",
+           "metadata": {
+                "description": "The name of the public subnet."
+            },
+            "defaultValue": "[concat(parameters('project'), '-', parameters('environment'), '-subnet-public')]"
+        },
+        "publicIpName": {
+           "type": "string",
+           "metadata": {
+                "description": "The name of the public IP resource."
+            },
+            "defaultValue": "[concat(parameters('vmName'), '-pip')]"
+        },
+        "privateNicName": {
+           "type": "string",
+           "metadata": {
+                "description": "The name of the private network interface."
+            },
+            "defaultValue": "[concat(parameters('vmName'), '-private-nic')]"
+        },
+        "publicNicName": {
+           "type": "string",
+           "metadata": {
+                "description": "The name of the public network interface."
+            },
+            "defaultValue": "[concat(parameters('vmName'), '-public-nic')]"
+        },
+        "vmSize": {
+           "type": "string",
+           "metadata": {
+                "description": "The size of the virtual machine."
+            },
+            "defaultValue": "Standard_B1ms"
+        },
+        "vmImage": {
+           "type": "object",
+           "metadata": {
+                "description": "The image for the virtual machines."
+            },
+            "defaultValue": {
+                "publisher": "center-for-internet-security-inc",
+                "offer": "cis-ubuntu-linux-1804-l1",
+                "sku": "cis-ubuntu1804-l1",
+                "version": "latest"
+            }
+        },
+        "vmPlan": {
+           "type": "object",
+           "metadata": {
+                "description": "The plan information for the virtual machine image."
+            },
+            "defaultValue": {
+                "name": "cis-ubuntu1804-l1",
+                "product": "cis-ubuntu-linux-1804-l1",
+                "publisher": "center-for-internet-security-inc"
+            }
+        },
+        "requiredUpTime": {
+           "type": "string",
+           "metadata": {
+                "description": "The tag describing the required uptime."
+           }
+        }
+    },
+    "variables": {
+        "privateSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('privateSubnetName'))]",
+        "publicSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('publicSubnetName'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "2019-11-01",
+            "name": "[parameters('publicIpName')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "Basic"
+            },
+            "properties": {
+                "publicIPAddressVersion": "IPv4",
+                "publicIPAllocationMethod": "Static",
+                "idleTimeoutInMinutes": 4,
+                "ipTags": []
+            }
+        },
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "2019-11-01",
+            "name": "[parameters('privateNicName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "private-ip-config",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('privateSubnetRef')]"
+                            },
+                            "primary": true
+                        }
+                    }
+                ],
+                "dnsSettings": {
+                    "dnsServers": []
+                },
+                "enableAcceleratedNetworking": false,
+                "enableIPForwarding": false
+            }
+        },
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "2019-11-01",
+            "name": "[parameters('publicNicName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIpName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "public-ip-config",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIpName'))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('publicSubnetRef')]"
+                            },
+                            "primary": true
+                        }
+                    }
+                ],
+                "dnsSettings": {
+                    "dnsServers": []
+                },
+                "enableAcceleratedNetworking": false,
+                "enableIPForwarding": false
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines",
+            "apiVersion": "2019-07-01",
+            "name": "[parameters('vmName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkInterfaces', parameters('publicNicName'))]",
+                "[resourceId('Microsoft.Network/networkInterfaces', parameters('privateNicName'))]"
+            ],
+            "tags": {
+                "requiredUptime": "[parameters('requiredUpTime')]"
+            },
+            "plan": "[parameters('vmPlan')]",
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                },
+                "storageProfile": {
+                    "imageReference": "[parameters('vmImage')]",
+                    "osDisk": {
+                        "osType": "Linux",
+                        "name": "[parameters('vmName')]",
+                        "createOption": "FromImage",
+                        "caching": "ReadOnly",
+                        "managedDisk": {
+                            "storageAccountType": "Standard_LRS"
+                        },
+                        "diskSizeGB": 30
+                    },
+                    "dataDisks": []
+                },
+                "osProfile": {
+                    "computerName": "[parameters('vmName')]",
+                    "adminUsername": "hsladmin",
+                    "linuxConfiguration": {
+                        "disablePasswordAuthentication": true,
+                        "ssh": {
+                            "publicKeys": [
+                                {
+                                    "path": "/home/hsladmin/.ssh/authorized_keys",
+                                    "keyData": "[parameters('initialSshKey')]"
+                                }
+                            ]
+                        },
+                        "provisionVMAgent": true
+                    },
+                    "secrets": [],
+                    "allowExtensionOperations": true
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('publicNicName'))]",
+                            "properties": {
+                                "primary": true
+                            }
+                        },
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('privateNicName'))]",
+                            "properties": {
+                                "primary": false
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "outputs": {},
+    "functions": []
+}


### PR DESCRIPTION
...based on the scripts provided in the HSL server-based repo:
https://gitlab.hsl.fi/platforms/server-based

Developers can log into the host using a public key, which has been
signed using the shared developer private key (stored in the common
Azure key vault).

Instructions for signing your own key as a developer in order to log
into the bastion host can be found here:
https://gitlab.hsl.fi/developer-resources/azure-ansible/-/tree/master#signing-users-public-key-with-private-ca-key

The CA key is stored in the hsl-jore4-vault, which is common to all
environments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-deploy/7)
<!-- Reviewable:end -->
