### PR TITLE
Apply deletion protection to resource group

### DIFF
--- a/ansible/templates/network.arm.json
+++ b/ansible/templates/network.arm.json
@@ -97,7 +97,16 @@
     },
     "variables": {},
     "resources": [
-        {
+      {
+            "type": "Microsoft.Authorization/locks",
+            "apiVersion": "2016-09-01",
+            "name": "resourceGroupLock",
+            "properties": {
+                "level": "CanNotDelete",
+                "notes": "Use the Owner role to delete resources."
+            }
+      },
+      {
             "type": "Microsoft.Network/virtualNetworks",
             "apiVersion": "2019-11-01",
             "name": "[parameters('vnetName')]",


### PR DESCRIPTION
As a side effect, applying the play-provision-rg-and-nets.yml playbook
requires the Owner-role in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-deploy/11)
<!-- Reviewable:end -->
