### PR TITLE
Set common resource group routing table on private subnet

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -4,6 +4,8 @@ az_project_name: "hsl-jore4"
 az_project_domain: "jore.hsl.fi"
 az_region_name: "westeurope"
 az_resource_group_name: "{{ az_project_name }}-{{ az_environment }}"
+az_common_resource_group_name: "{{ az_project_name }}-common"
+az_private_route_table_name: "jore4-route"
 
 #Common packages
 default_packages:

--- a/ansible/roles/azure_network/tasks/main.yml
+++ b/ansible/roles/azure_network/tasks/main.yml
@@ -20,6 +20,10 @@
         value: "{{ az_bastion_host_trusted_ips }}"
       gatewayTrustedAddresses:
         value: "{{ az_gateway_trusted_ips }}"
+      commonResourceGroupName:
+        value: "{{ az_common_resource_group_name }}"
+      privateRouteTableName:
+        value: "{{ az_private_route_table_name }}"
     tags:
       ansible: "workaround"
     template: "{{ lookup('file', 'templates/network.arm.json') }}"

--- a/ansible/templates/network.arm.json
+++ b/ansible/templates/network.arm.json
@@ -93,6 +93,20 @@
                 "description": "The name of the gateway Network Security Group."
             },
             "defaultValue": "[concat(parameters('project'), '-', parameters('environment'), '-nsg-gateway')]"
+        },
+        "commonResourceGroupName": {
+            "type": "string",
+            "metadata": {
+              "description": "The name of the resource group common to all envs."
+            },
+            "defaultValue": "[concat(parameters('project'), '-common')]"
+        },
+        "privateRouteTableName": {
+            "type": "string",
+            "metadata": {
+              "description": "The name of the route table to use with the private subnet."
+            },
+            "defaultValue": "[concat(parameters('project'), '-route')]"
         }
     },
     "variables": {},
@@ -120,6 +134,9 @@
                             "addressPrefix": "[concat(parameters('cidrPrefix'), '.0/25')]",
                             "networkSecurityGroup": {
                                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('privateNsgName'))]"
+                            },
+                            "routeTable": {
+                                "id": "[resourceId(parameters('commonResourceGroupName'), 'Microsoft.Network/routeTables', parameters('privateRouteTableName'))]"
                             }
                         }
                     },


### PR DESCRIPTION
This change sets the routing table defined in the common resource group
to be used in the private subnet defined in network.arm.json .

When troubleshooting the Jore3 DB connection, check that
- the correct routing table is set on the private subnet (via this
  commit)
- the bastion host has the correct routing entry in use and
- the firewall on Jore3 DB's side is configured properly.

For more information, please see
https://github.com/HSLdevcom/jore4/blob/main/wiki/jore3.md#troubleshooting-jore3-db-access

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-deploy/12)
<!-- Reviewable:end -->
