### PR TITLE
Fix: Move vnet address space parameters to ansible/group_vars/all.yml

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -18,6 +18,7 @@ az_private_subnet_router_ip: "{{ cidr_prefix }}.1"  # In Azure always ".1", see 
 az_private_aci_subnet_addr_prefix: "{{ cidr_prefix }}.128/26"
 az_public_subnet_addr_prefix: "{{ cidr_prefix }}.232/29"
 az_gateway_subnet_addr_prefix: "{{ cidr_prefix }}.240/28"
+az_db_subnet_addr_prefix: "{{ cidr_prefix }}.192/28"
 az_jore3_db_net: "10.218.6.0/27"
 
 # Bastion host

--- a/ansible/roles/azure_network/tasks/main.yml
+++ b/ansible/roles/azure_network/tasks/main.yml
@@ -24,6 +24,8 @@
         value: "{{ az_public_subnet_addr_prefix }}"
       gatewaySubnetAddrPrefix:
         value: "{{ az_gateway_subnet_addr_prefix }}"
+      dbSubnetAddrPrefix:
+        value: "{{ az_db_subnet_addr_prefix }}"
       bastionTrustedAddresses:
         value: "{{ az_bastion_host_trusted_ips }}"
       commonResourceGroupName:

--- a/ansible/templates/network.arm.json
+++ b/ansible/templates/network.arm.json
@@ -93,6 +93,19 @@
         "description": "The address prefix (e.g. '10.223.12.240/28') of the gateway subnet."
       }
     },
+    "dbSubnetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the db subnet."
+      },
+      "defaultValue": "[concat(parameters('project'), '-', parameters('environment'), '-subnet-private-db')]"
+    },
+    "dbSubnetAddrPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The address prefix (e.g. '10.223.12.192/28') of the db subnet."
+      }
+    },
     "privateNsgName": {
       "type": "string",
       "metadata": {
@@ -197,9 +210,9 @@
             }
           },
           {
-            "name": "[concat(parameters('privateSubnetName'),'-db')]",
+            "name": "[parameters('dbSubnetName')]",
             "properties": {
-              "addressPrefix": "[concat(parameters('cidrPrefix'), '.192/28')]",
+              "addressPrefix": "[parameters('dbSubnetAddrPrefix')]",
               "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('privateNsgName'))]"
               },


### PR DESCRIPTION
The db subnet configuration was missing from the above mentioned
previous commit due to the db change having been merged after the
creation of that commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-deploy/25)
<!-- Reviewable:end -->
