### PR TITLE
Deploy public subnet NSG only if it does not exist yet

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -5,6 +5,7 @@ az_project_domain: "jore.hsl.fi"
 az_region_name: "westeurope"
 az_resource_group_name: "{{ az_project_name }}-{{ az_environment }}"
 az_common_resource_group_name: "{{ az_project_name }}-common"
+az_public_nsg_name: "{{ az_resource_group_name }}-nsg-public"
 
 #Common packages
 default_packages:

--- a/ansible/roles/azure_network/tasks/main.yml
+++ b/ansible/roles/azure_network/tasks/main.yml
@@ -4,6 +4,8 @@
     msg: "cidr_prefix {{ cidr_prefix }} is not valid. You should update the variable with a value that was reserved for your environment."
   when: not cidr_prefix is regex("[0-9]{1,3}[.][0-9]{1,3}[.][0-9]{1,3}")
 
+- include_tasks: public-subnet-nsg.yml
+
 - name: Create Azure Deployment for network
   azure_rm_deployment:
     resource_group: "{{ az_resource_group_name }}"
@@ -26,12 +28,12 @@
         value: "{{ az_gateway_subnet_addr_prefix }}"
       dbSubnetAddrPrefix:
         value: "{{ az_db_subnet_addr_prefix }}"
-      bastionTrustedAddresses:
-        value: "{{ az_bastion_host_trusted_ips }}"
       commonResourceGroupName:
         value: "{{ az_common_resource_group_name }}"
       routeTableName:
         value: "{{ az_route_table_name }}"
+      publicNsgName:
+        value: "{{ az_public_nsg_name }}"
     tags:
       ansible: "workaround"
     template: "{{ lookup('file', 'templates/network.arm.json') }}"

--- a/ansible/roles/azure_network/tasks/public-subnet-nsg.yml
+++ b/ansible/roles/azure_network/tasks/public-subnet-nsg.yml
@@ -1,0 +1,24 @@
+---
+- name: Check if the public subnet NSG exists
+  shell: "az network nsg list --resource-group {{ az_resource_group_name }} --query \"[?name=='{{ az_public_nsg_name }}'].{id:id}[0].id\""
+  register: nsg_id
+
+- debug:
+    msg: "{{ nsg_id.stdout }}"
+
+- name: Create Azure Deployment for the public subnet NSG if it does not exist yet
+  when: nsg_id.stdout == ""
+  azure_rm_deployment:
+    resource_group: "{{ az_resource_group_name }}"
+    location: "{{ az_region_name }}"
+    name: "azure_network_common"
+    parameters:
+      project:
+        value: "{{ az_project_name }}"
+      bastionTrustedAddresses:
+        value: "{{ az_bastion_host_trusted_ips }}"
+      publicNsgName:
+        value: "{{ az_public_nsg_name }}"
+    tags:
+      ansible: "workaround"
+    template: "{{ lookup('file', 'templates/public-subnet-nsg.arm.json') }}"

--- a/ansible/templates/network.arm.json
+++ b/ansible/templates/network.arm.json
@@ -14,13 +14,6 @@
         "description": "The target environment. Typically dev, test or prod."
       }
     },
-    "bastionTrustedAddresses": {
-      "type": "array",
-      "metadata": {
-        "description": "The IP addresses allowed to SSH into the environment."
-      },
-      "defaultValue": ["194.100.20.48/28"]
-    },
     "location": {
       "type": "string",
       "metadata": {
@@ -169,7 +162,6 @@
       "location": "[parameters('location')]",
       "dependsOn": [
         "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('privateNsgName'))]",
-        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('publicNsgName'))]",
         "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('gatewayNsgName'))]"
       ],
       "properties": {
@@ -257,33 +249,6 @@
         "virtualNetworkPeerings": [],
         "enableDdosProtection": false,
         "enableVmProtection": false
-      }
-    },
-    {
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2019-11-01",
-      "name": "[parameters('publicNsgName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "securityRules": [
-          {
-            "name": "allow_SSH",
-            "properties": {
-              "protocol": "TCP",
-              "sourcePortRange": "*",
-              "destinationPortRange": "22",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 100,
-              "direction": "Inbound",
-              "sourcePortRanges": [],
-              "destinationPortRanges": [],
-              "sourceAddressPrefixes": "[parameters('bastionTrustedAddresses')]",
-              "destinationAddressPrefixes": []
-            }
-          },
-          "[variables('denyInternetRule')]"
-        ]
       }
     },
     {

--- a/ansible/templates/public-subnet-nsg.arm.json
+++ b/ansible/templates/public-subnet-nsg.arm.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "project": {
+      "type": "string",
+      "metadata": {
+        "description": "The short name of the project. Usually same as the name of the subscription in Azure."
+      }
+    },
+    "bastionTrustedAddresses": {
+      "type": "array",
+      "metadata": {
+        "description": "The IP addresses allowed to SSH into the environment."
+      },
+      "defaultValue": []
+    },
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "The region used for the resources."
+      },
+      "defaultValue": "[resourceGroup().location]"
+    },
+    "publicNsgName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the public Network Security Group."
+      },
+      "defaultValue": "[concat(parameters('project'), '-', 'common')]"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-11-01",
+      "name": "[parameters('publicNsgName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "allow_SSH",
+            "properties": {
+              "protocol": "TCP",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": "[parameters('bastionTrustedAddresses')]",
+              "destinationAddressPrefixes": []
+            }
+          },
+          {
+            "name": "deny_internet",
+            "properties": {
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Deny",
+              "priority": 1000,
+              "direction": "Inbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {},
+  "functions": []
+}


### PR DESCRIPTION
This way, the NSG can be modified manually without the changes being
reverted the next time the rg-and-nets -playbook is run.

This can be used to configure custom IP ranges in the public subnet NSG
for bastion host access.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-deploy/28)
<!-- Reviewable:end -->
