### PR TITLE
Deploy public subnet NSG only if it does not exist yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ to do so as they have dependencies between each other.
 
 If the given resources with the same name already exist, they are overwritten with the resources
 described by the scripts. Other resources are not modified or delete unless explicitly mentioned in
-the script description.
+the script description. One exception to this is the public network security group (NSG), see
+[1. Provisioning resource groups and network](#1-provisioning-resource-groups-and-network) for details.
 
 _For simplicity, the scripts below are only showing what happens in the DEV environment. The exact
 same outcome is expected when using the `playtest` and `playprod` aliases._
@@ -154,6 +155,9 @@ Creates basic network setup:
   - `hsl-jore4-dev-subnet-gateway` (public subnet to allow access from Internet. E.g. HTTP requests)
 
 The subnets can freely access resources between each other.
+
+Note that the public network security group (NSG) is only deployed if it does not exist yet. This
+allows for manual modifications like custom firewall settings to survive later  re-deployments.
 
 The routing table `jore4-route` is configured on all subnets in order to be able to restrict the
 traffic between the subnets and the peered vnet hosting the jore3 database. The traffic is

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Deployment scripts for provisioning and configuring JORE4 infrastructure in Azur
 
 - [Preliminaries](#preliminaries)
 - [Development](#development)
-- [How to Run](#how-to-run)
-- [Roles](#roles)
+  - [How to Run](#how-to-run)
+  - [Subscriptions](#subscriptions)
+  - [Roles](#roles)
 - [Scripts](#scripts)
   - [Provisioning](#provisioning)
     - [1. Provisioning resource groups and network](#1-provisioning-resource-groups-and-network)
@@ -28,6 +29,7 @@ Deployment scripts for provisioning and configuring JORE4 infrastructure in Azur
       - [Nodes, ACI burst](#nodes-aci-burst)
       - [Application Gateway Ingress Controller](#application-gateway-ingress-controller)
       - [Accessing the Cluster](#accessing-the-cluster)
+      - [Binding secrets to Pods](#binding-secrets-to-pods)
       - [Troubleshooting AKS](#troubleshooting-aks)
     - [7. Provisioning a Domain](#7-provisioning-a-domain)
     - [8. Provisioning a Certificate](#8-provisioning-a-certificate)
@@ -62,7 +64,7 @@ Deployment scripts for provisioning and configuring JORE4 infrastructure in Azur
 When making changes to this codebase, CI automatically runs Github [Super-Linter](https://github.com/github/super-linter) to check the code
 format. To run it manually, use `./development.sh lint`.
 
-# How to Run
+## How to Run
 
 The deployment scripts are in the form of Ansible playbooks. To run the playbooks, we are using HSL's
 [hsldevcom/azure-ansible](https://gitlab.hsl.fi/developer-resources/azure-ansible) docker image.
@@ -81,11 +83,19 @@ exit the shell, just type `exit`.
 There are preconfigured aliases (`playdev`, `playtest`, `playprod`) in the interactive shell to
 simplify running the scripts against a chosen environment.
 
-# Roles
+## Subscriptions
+
+When first logging in to Azure with `az login` (e.g. for your Ansible scripts or for Kubernetes),
+your subscription by default will be pointed to the HSL default subscription. To be able to create
+and view resources in the JORE4 subscription, you have to point your Azure CLI to the proper
+context by using: `az account set --subscription "jore4"`
+
+Note that `start-ansible-shell.sh` and `kubernetes.sh` automatically does this for you.
+
+## Roles
 
 For some scripts, you need to temporarily elevate your role to e.g. create new role bindings for
 managed identities. You may do so [here](https://portal.azure.com/#blade/Microsoft_Azure_PIMCommon/ActivationMenuBlade/azurerbac/provider/azurerbac).
-
 
 # Scripts
 
@@ -100,14 +110,9 @@ the script description.
 _For simplicity, the scripts below are only showing what happens in the DEV environment. The exact
 same outcome is expected when using the `playtest` and `playprod` aliases._
 
-# Subscriptions
+Note that in ARM deployments, the `ansible: workaround` tag has to be used in order to prevent the
+removal of all tags of the resource group due to a bug in the ansible ARM plugin.
 
-When first logging in to Azure with `az login` (e.g. for your Ansible scripts or for Kubernetes),
-your subscription by default will be pointed to the HSL default subscription. To be able to create
-and view resources in the JORE4 subscription, you have to point your Azure CLI to the proper
-context by using: `az account set --subscription "jore4"`
-
-Note that `start-ansible-shell.sh` and `kubernetes.sh` automatically does this for you.
 
 ## Provisioning
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -5,6 +5,7 @@ az_project_domain: "jore.hsl.fi"
 az_region_name: "westeurope"
 az_resource_group_name: "{{ az_project_name }}-{{ az_environment }}"
 az_common_resource_group_name: "{{ az_project_name }}-common"
+az_public_nsg_name: "{{ az_resource_group_name }}-nsg-public"
 
 #Common packages
 default_packages:

--- a/ansible/roles/azure_network/tasks/main.yml
+++ b/ansible/roles/azure_network/tasks/main.yml
@@ -4,6 +4,13 @@
     msg: "cidr_prefix {{ cidr_prefix }} is not valid. You should update the variable with a value that was reserved for your environment."
   when: not cidr_prefix is regex("[0-9]{1,3}[.][0-9]{1,3}[.][0-9]{1,3}")
 
+- name: Check if the public subnet NSG exists
+  shell: "az network nsg list --resource-group {{ az_resource_group_name }} --query \"[?name=='{{ az_public_nsg_name }}'].{id:id}[0].id\""
+  register: public_nsg_id
+
+- debug:
+    msg: "Public subnet NSG id (empty if non-existent): {{ public_nsg_id.stdout }}"
+
 - name: Create Azure Deployment for network
   azure_rm_deployment:
     resource_group: "{{ az_resource_group_name }}"
@@ -32,6 +39,10 @@
         value: "{{ az_common_resource_group_name }}"
       routeTableName:
         value: "{{ az_route_table_name }}"
+      publicNsgName:
+        value: "{{ az_public_nsg_name }}"
+      deployPublicNsg:
+        value: "{{ true if (public_nsg_id.stdout == \"\") else false }}"
     tags:
       ansible: "workaround"
     template: "{{ lookup('file', 'templates/network.arm.json') }}"

--- a/ansible/templates/network.arm.json
+++ b/ansible/templates/network.arm.json
@@ -140,6 +140,13 @@
         "description": "The name of the route table to use with all subnets."
       },
       "defaultValue": "[concat(parameters('project'), '-route')]"
+    },
+    "deployPublicNsg": {
+      "type": "bool",
+      "metadata": {
+        "description": "Whether to deploy the public NSG. If not true, creation will be omitted."
+      },
+      "defaultValue": "true"
     }
   },
   "variables": {
@@ -260,6 +267,7 @@
       }
     },
     {
+      "condition": "[parameters('deployPublicNsg')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2019-11-01",
       "name": "[parameters('publicNsgName')]",


### PR DESCRIPTION
This way, the NSG can be modified manually without the changes being
reverted the next time the rg-and-nets -playbook is run.

This can be used to configure custom IP ranges in the public subnet NSG
for bastion host access.

Fixes HSLdevcom/jore4#83

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-deploy/33)
<!-- Reviewable:end -->
